### PR TITLE
Update Create_Image.mustache

### DIFF
--- a/imagetool/src/main/resources/docker-files/Create_Image.mustache
+++ b/imagetool/src/main/resources/docker-files/Create_Image.mustache
@@ -252,6 +252,7 @@ COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
 
 {{#isWdtEnabled}}
     {{#modelOnly}}
+        USER root
         RUN DOMAIN_PARENT=$(dirname {{{domain_home}}}) \
         && mkdir -p $DOMAIN_PARENT \
         && chown {{userid}}:{{groupid}} $DOMAIN_PARENT \
@@ -262,10 +263,13 @@ COPY --from=WLS_BUILD --chown={{userid}}:{{groupid}} {{{oracle_home}}} {{{oracle
         {{#isWdtModelHomeOutsideWdtHome}}
             COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{wdt_model_home}} {{wdt_model_home}}/
         {{/isWdtModelHomeOutsideWdtHome}}
+        USER {{userid}}
     {{/modelOnly}}
     {{^modelOnly}}
+        USER root
         COPY --from=WDT_BUILD --chown={{userid}}:{{groupid}} {{{domain_home}}} {{{domain_home}}}/
         RUN chmod g+w {{{domain_home}}}
+        USER {{userid}}
     {{/modelOnly}}
 {{/isWdtEnabled}}
 


### PR DESCRIPTION
Fix issue with chown to root not being allowed by non-root user in SELINUX enforced distros.